### PR TITLE
quick fix for VS2019/Qt 5.15 build

### DIFF
--- a/stunts/stressed/README
+++ b/stunts/stressed/README
@@ -19,6 +19,21 @@ DEPENDENCIES
 BUILDING
 
  Run "qmake" to generate makefiles and then "make" to build.
+ 
+ Build with VS2019 Community/Qt5.15 Open Source under Win7:
+   install Qt with maintainance tool or build from source
+   enter folder with stressed.pro
+   qmake
+   nmake
+   goto to the folder src\app\release
+   add following Qt dlls
+    
+   Qt5Core.dll
+   Qt5Gui.dll
+   Qt5OpenGL.dll
+   Qt5Widgets.dll
+   \platforms
+     qwindows.dll
 
 USAGE
 
@@ -33,4 +48,4 @@ CONTACT
 
  Daniel Stien <daniel@stien.org>
  Daniel Mlot <duplode_1@yahoo.com.br>
- http://stuntstools.googlecode.com/
+ https://github.com/dstien/gameformats/tree/master/stunts/stressed

--- a/stunts/stressed/README
+++ b/stunts/stressed/README
@@ -23,15 +23,14 @@ BUILDING
  Build Examples:
  
  Build with VS2019 Community/Qt5.15 Open Source under Win7:
-   1. install Qt 32 and 64 Bit with maintainance tool or build from source
+   1. install Qt 32 and/or 64 Bit with maintainance tool or build from source
    2. start Visual Studio Command shell (or vcvars) to have build tools available
    3. git clone https://github.com/dstien/gameformats.git
    4. cd gameformats/stunts/stressed
-   5. enter folder with stressed.pro
-   6. c:\Qt\5.15.0\msvc2019\bin\qmake.exe
-   7. nmake
-   8. goto to the folder src\app\release
-   9. add following Qt dlls from your Qt Installation
+   5. c:\Qt\5.15.0\msvc2019\bin\qmake.exe
+   6. nmake
+   7. goto to the folder src\app\release
+   8. add following Qt dlls from your Qt Installation
     
       Qt5Core.dll
       Qt5Gui.dll

--- a/stunts/stressed/README
+++ b/stunts/stressed/README
@@ -20,20 +20,38 @@ BUILDING
 
  Run "qmake" to generate makefiles and then "make" to build.
  
+ Build Examples:
+ 
  Build with VS2019 Community/Qt5.15 Open Source under Win7:
-   install Qt with maintainance tool or build from source
-   enter folder with stressed.pro
-   qmake
-   nmake
-   goto to the folder src\app\release
-   add following Qt dlls
+   1. install Qt 32 and 64 Bit with maintainance tool or build from source
+   2. start Visual Studio Command shell (or vcvars) to have build tools available
+   3. git clone https://github.com/dstien/gameformats.git
+   4. cd gameformats/stunts/stressed
+   5. enter folder with stressed.pro
+   6. c:\Qt\5.15.0\msvc2019\bin\qmake.exe
+   7. nmake
+   8. goto to the folder src\app\release
+   9. add following Qt dlls from your Qt Installation
     
-   Qt5Core.dll
-   Qt5Gui.dll
-   Qt5OpenGL.dll
-   Qt5Widgets.dll
-   \platforms
-     qwindows.dll
+      Qt5Core.dll
+      Qt5Gui.dll
+      Qt5OpenGL.dll
+      Qt5Widgets.dll
+      \platforms
+        qwindows.dll
+     
+  Build under Ubunut 20.04 LTS/Minimal Installation
+    1. sudo apt update
+    2. sudo apt upgrade
+    3. sudo apt install build-essential # for gcc
+    4. sudo apt install mesa-common-dev # for opengl
+    5. sudo apt install qt5-default
+    6. sudo apt install git
+    7. git clone https://github.com/dstien/gameformats.git
+    8. cd gameformats/stunts/stressed
+    9. qmake
+    10. make
+    11. ./src/app/stressed
 
 USAGE
 

--- a/stunts/stressed/src/app/app.pro
+++ b/stunts/stressed/src/app/app.pro
@@ -11,20 +11,20 @@ INCLUDEPATH += $$DEPENDPATH
 
 win32 {
   CONFIG(release, debug|release) {
-    PRE_TARGETDEPS += ../animation/release/libanimation.a \
-                      ../bitmap/release/libbitmap.a \
-                      ../raw/release/libraw.a \
-                      ../shape/release/libshape.a \
-                      ../speed/release/libspeed.a \
-                      ../text/release/libtext.a
+    PRE_TARGETDEPS += ../animation/release/animation.lib \
+                      ../bitmap/release/bitmap.lib \
+                      ../raw/release/raw.lib \
+                      ../shape/release/shape.lib \
+                      ../speed/release/speed.lib \
+                      ../text/release/text.lib
   }
   else {
-    PRE_TARGETDEPS += ../animation/debug/libanimation.a \
-                      ../bitmap/debug/libbitmap.a \
-                      ../raw/debug/libraw.a \
-                      ../shape/debug/libshape.a \
-                      ../speed/debug/libspeed.a \
-                      ../text/debug/libtext.a
+    PRE_TARGETDEPS += ../animation/debug/animation.lib \
+                      ../bitmap/debug/bitmap.lib \
+                      ../raw/debug/raw.lib \
+                      ../shape/debug/shape.lib \
+                      ../speed/debug/speed.lib \
+                      ../text/debug/text.lib
   }
   LIBS += $$PRE_TARGETDEPS -lopengl32 -lglu32
 

--- a/stunts/stressed/src/app/mainwindow.cpp
+++ b/stunts/stressed/src/app/mainwindow.cpp
@@ -319,7 +319,7 @@ void MainWindow::about()
   QMessageBox::about(this, tr("About stressed"),
       tr("<div align=\"center\"><h1>%1 %2</h1><br/>"
          "%3<br/>"
-         "Using Qt 5.15/%5<br/>"
+         "Using Qt " QT_VERSION_STR "/%5<br/>"
          "<a href=\"%4\">%4</a><br/><br/>"
          "<em>Thanks to the Stunts community<br>"
          "for keeping the game alive!</em><br><br>"

--- a/stunts/stressed/src/app/mainwindow.cpp
+++ b/stunts/stressed/src/app/mainwindow.cpp
@@ -21,6 +21,7 @@
 #include <QLabel>
 #include <QMessageBox>
 #include <QUrl>
+#include <QtGlobal>
 
 #include "mainwindow.h"
 #include "resourcesmodel.h"
@@ -318,7 +319,7 @@ void MainWindow::about()
   QMessageBox::about(this, tr("About stressed"),
       tr("<div align=\"center\"><h1>%1 %2</h1><br/>"
          "%3<br/>"
-         "Using Qt "QT_VERSION_STR"/%5<br/>"
+         "Using Qt 5.15/%5<br/>"
          "<a href=\"%4\">%4</a><br/><br/>"
          "<em>Thanks to the Stunts community<br>"
          "for keeping the game alive!</em><br><br>"

--- a/stunts/stressed/src/app/settings.cpp
+++ b/stunts/stressed/src/app/settings.cpp
@@ -27,7 +27,7 @@ const char Settings::APP_AUTHOR[]  = "Daniel Stien";
 const char Settings::APP_CONTACT[] = "daniel@stien.org";
 
 const char Settings::ORG_NAME[] = "stuntstools";
-const char Settings::ORG_URL[]  = "http://stuntstools.googlecode.com/";
+const char Settings::ORG_URL[]  = "https://github.com/dstien/gameformats/tree/master/stunts/stressed";
 const char Settings::MAN_URL[]  = "http://wiki.stunts.hu/index.php/Stressed_user_reference";
 
 const char Settings::DEFAULTS[] = ":/conf/defaults.conf";

--- a/stunts/stressed/src/shape/shapemodel.cpp
+++ b/stunts/stressed/src/shape/shapemodel.cpp
@@ -18,7 +18,8 @@
 #include <QItemSelectionModel>
 #include <QStringList>
 #include <QVector3D>
-#include <cmath>
+#define _USE_MATH_DEFINES
+#include <math.h>
 
 #include "materialsmodel.h"
 #include "shapemodel.h"
@@ -446,9 +447,9 @@ void ShapeModel::computeCull(Primitive& primitive)
     QVector3D edge2 = vertices->at(2).toQ() - vertices->at(0).toQ();
     QVector3D normal = QVector3D::normal(edge1, edge2);
 
-    float yAngle = std::acos(QVector3D::dotProduct(normal, QVector3D(0.0f, 1.0f, 0.0f))) * (180.0f / M_PI);
+    float yAngle = acos(QVector3D::dotProduct(normal, QVector3D(0.0f, 1.0f, 0.0f))) * (180.0f / M_PI);
 
-    if (!std::isnan(yAngle)) {
+    if (!isnan(yAngle)) {
       // C1 flags
       if (yAngle >= 0.0f && yAngle < 135.0f) {   // C1+
         primitive.cull1 |= PRIM_CULL_POS_FLAG;
@@ -506,7 +507,7 @@ void ShapeModel::computeCull(Primitive& primitive)
       }
 
       // Rotate fields
-      int rotation  = (int)(((M_PI + std::atan2(normal.x(), normal.z())) / (2.0f * M_PI)) * 15.0f + 0.5f);
+      int rotation  = (int)(((M_PI + atan2(normal.x(), normal.z())) / (2.0f * M_PI)) * 15.0f + 0.5f);
 
       if (c1p) {
         if (c1p == PRIM_CULL_15BITS) {

--- a/stunts/stressed/src/shape/shapeview.cpp
+++ b/stunts/stressed/src/shape/shapeview.cpp
@@ -15,11 +15,13 @@
 // along with this program; if not, write to the Free Software
 // Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 
+#include <windows.h>
 #include <GL/glu.h>
 #include <QGLWidget>
 #include <QPaintEvent>
 #include <QVector3D>
-#include <cmath>
+#define _USE_MATH_DEFINES
+#include <math.h>
 
 #include "app/settings.h"
 #include "materialsmodel.h"
@@ -321,8 +323,8 @@ void ShapeView::drawSphere(const VerticesFList* vertices)
   glBegin(GL_TRIANGLE_FAN);
   for (int j = 0; j < CIRCLE_STEPS; j++) {
     glVertex3f(
-        std::cos((PI2 * (j + 1)) / CIRCLE_STEPS) * radius,
-        std::sin((PI2 * (j + 1)) / CIRCLE_STEPS) * radius,
+        cos((PI2 * (j + 1)) / CIRCLE_STEPS) * radius,
+        sin((PI2 * (j + 1)) / CIRCLE_STEPS) * radius,
         0.0f);
   }
   glEnd();
@@ -348,14 +350,14 @@ void ShapeView::drawWheel(const VerticesFList* vertices, int& material, bool& pa
   QVector3D edge2 = vertices->at(2).toQ() - vertices->at(0).toQ();
   QVector3D normal = QVector3D::normal(edge1, edge2);
 
-  float rotation  = std::atan2(normal.x(), normal.z()) * (180.0f / M_PI);
+  float rotation  = atan2(normal.x(), normal.z()) * (180.0f / M_PI);
   glRotatef(rotation, 0.0f, 1.0f, 0.0f);
 
   // X/Y coordinates
   float x1[CIRCLE_STEPS], y1[CIRCLE_STEPS], x2[CIRCLE_STEPS], y2[CIRCLE_STEPS];
   for (int i = 0; i < CIRCLE_STEPS; i++) {
-    float x = std::cos((PI2 * (i + 1)) / CIRCLE_STEPS);
-    float y = std::sin((PI2 * (i + 1)) / CIRCLE_STEPS);
+    float x = cos((PI2 * (i + 1)) / CIRCLE_STEPS);
+    float y = sin((PI2 * (i + 1)) / CIRCLE_STEPS);
     x1[i] = x * radius1h;
     y1[i] = y * radius1v;
     x2[i] = x * radius2h;
@@ -463,8 +465,8 @@ void ShapeView::drawCullData(const Primitive& primitive)
       if (j % 2) m_glWidget->qglColor(Qt::darkGreen);
       else       m_glWidget->qglColor(Qt::green);
     }
-    x =  std::cos((PI2 * (j + 1)) / steps);
-    z = -std::sin((PI2 * (j + 1)) / steps);
+    x =  cos((PI2 * (j + 1)) / steps);
+    z = -sin((PI2 * (j + 1)) / steps);
     glVertex3f(x * radius2 + center.x, center.y, z * radius2 + center.z);
     glVertex3f(x * radius3 + center.x, center.y, z * radius3 + center.z);
   }
@@ -482,8 +484,8 @@ void ShapeView::drawCullData(const Primitive& primitive)
       if (j % 2) m_glWidget->qglColor(Qt::darkGreen);
       else       m_glWidget->qglColor(Qt::green);
     }
-    x = std::cos((PI2 * (j + 1)) / steps);
-    z = std::sin((PI2 * (j + 1)) / steps);
+    x = cos((PI2 * (j + 1)) / steps);
+    z = sin((PI2 * (j + 1)) / steps);
     glVertex3f(x * radius2 + center.x, center.y, z * radius2 + center.z);
     glVertex3f(x * radius3 + center.x, center.y, z * radius3 + center.z);
   }
@@ -501,8 +503,8 @@ void ShapeView::drawCullData(const Primitive& primitive)
       if (j % 2) m_glWidget->qglColor(Qt::darkYellow);
       else       m_glWidget->qglColor(Qt::yellow);
     }
-    x =  std::cos((PI2 * (j + 1)) / steps);
-    z = -std::sin((PI2 * (j + 1)) / steps);
+    x =  cos((PI2 * (j + 1)) / steps);
+    z = -sin((PI2 * (j + 1)) / steps);
     glVertex3f(x * radius1 + center.x, center.y, z * radius1 + center.z);
     glVertex3f(x * radius2 + center.x, center.y, z * radius2 + center.z);
   }
@@ -520,8 +522,8 @@ void ShapeView::drawCullData(const Primitive& primitive)
       if (j % 2) m_glWidget->qglColor(Qt::darkYellow);
       else       m_glWidget->qglColor(Qt::yellow);
     }
-    x = std::cos((PI2 * (j + 1)) / steps);
-    z = std::sin((PI2 * (j + 1)) / steps);
+    x = cos((PI2 * (j + 1)) / steps);
+    z = sin((PI2 * (j + 1)) / steps);
     glVertex3f(x * radius1 + center.x, center.y, z * radius1 + center.z);
     glVertex3f(x * radius2 + center.x, center.y, z * radius2 + center.z);
   }


### PR DESCRIPTION
app.pro: Visual Studio creates different lib names (its possible to seperate the changes with `win32-msvc* {` )
shapemodel.cpp/shapeview.cpp: Some sort of Mirosoft Problem #define + cmath does not work for M_PI, #define + math.h works for M_PI but then the std-namespaces is gone